### PR TITLE
Add-AdminController

### DIFF
--- a/app/assets/stylesheets/amazonweb.css.scss
+++ b/app/assets/stylesheets/amazonweb.css.scss
@@ -240,6 +240,151 @@
   }
 }
 
+// 管理者ページ
+// ヘッダー
+.adminheader{
+  height: 50px;
+  width: 100%;
+  background-color: #232f3e;
+  border: 2px;
+  border-bottom:solid;
+  border-style: medium;
+  border-color: #a2a2a2;
+  color: #FFFFFF;
+  &__title{
+    float: left;
+    padding-top: 15px;
+    padding-left: 30px;
+  }
+  &__username{
+    float: left;
+    padding-left: 100px;
+  }
+  &__buttons{
+    float: left;
+    padding-left: 100px;
+    &__sitebutton{
+      float: left;
+    }
+    &__logoutbutton{
+      float: left;
+    }
+  }
+}
+
+// ボタン類
+.adminheader__buttons__sitebutton{
+    display: inline-block;
+    padding: 0.5em 1em;
+    text-decoration: none;
+    background: #668ad8;/*ボタン色*/
+    color: #FFFFFF;
+    border-bottom: solid 4px #627295;
+    border-radius: 3px;
+    margin-left: 30px;
+}
+
+.adminheader__buttons__logoutbutton{
+    display: inline-block;
+    padding: 0.5em 1em;
+    text-decoration: none;
+    background: #668ad8;/*ボタン色*/
+    color: #FFFFFF;
+    border-bottom: solid 4px #627295;
+    border-radius: 3px;
+    margin-left: 30px;
+}
+.adminheader__buttons:active {/*ボタンを押したとき*/
+    -ms-transform: translateY(4px);
+    -webkit-transform: translateY(4px);
+    transform: translateY(4px);/*下に動く*/
+    border-bottom: none;/*線を消す*/
+}
+
+.adminheader__buttons a{
+  color: #FFFFFF;
+  text-decoration: none;
+}
+
+
+// 本体部分
+// 左サイドバー
+.adminleftwindow{
+  float: left;
+  &__linkbox{
+    width: 200px;
+    height: 800px;
+    background-color: #f5f5f5;
+    padding-left: 10px;
+    &__title{
+      font-size: 20px;
+      padding-top: 10px;
+    }
+    &__links{
+      font-size: 16px;
+      padding-left: 10px;
+    }
+  }
+}
+
+.adminleftwindow__linkbox__links a{
+  color: #0000FF;
+  text-decoration: none;
+}
+
+// メインウィンドウ
+.adminmainwindow{
+  width: 100%;
+  padding-left: 200px;
+  height: 800px;
+  background-color: #cccccc;
+  &__boxes{
+    &__orders{
+      padding-top: 20px;
+    }
+    &__stocks{
+      padding-top: 300px;
+    }
+  }
+  &__title{
+    padding-left: 20px;
+    font-size: 24px;
+  }
+  &__fields{
+    padding-left: 20px;
+    padding-top: 20px;
+    font-size: 20px;
+  }
+}
+
+.SendButton{
+    display: inline-block;
+    padding: 0.5em 1em;
+    width: 100px;
+    text-decoration: none;
+    background: #668ad8;/*ボタン色*/
+    color: #FFFFFF;
+    border-bottom: solid 4px #627295;
+    border-radius: 3px;
+}
+
+
+// フッター部分
+.adminfooter{
+  clear: both;
+  text-align: center;
+  width: 100%;
+  height: 50px;
+  background-color: #232f3e;
+  color: #FFFFFF;
+  &__title{
+
+  }
+  &__message{
+
+  }
+}
+
 
 // エラー画面
 .errorwindow{

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,18 @@
+class AdminController < ApplicationController
+
+  before_action :permission_check
+
+  def index
+  end
+
+  private
+  def permission_check
+    #権限制御 トップページが出来上がってから動作させる。
+    if user_signed_in?
+      if current_user.admin_flg == nil
+        render "errors/forbidden"
+      end
+    end
+  end
+
+end

--- a/app/controllers/concerns/error_handlers.rb
+++ b/app/controllers/concerns/error_handlers.rb
@@ -2,11 +2,8 @@ module ErrorHandlers
   extend ActiveSupport::Concern
 
   included do
-    rescue_from Exception, with: :rescue500
     rescue_from ApplicationController::Forbidden, with: :rescue403
     rescue_from ApplicationController::IpAddressRejected, with: :rescue403
-    rescue_from ActionController::RoutingError, with: :rescue404
-    rescue_from ActiveRecord::RecordNotFound, with: :rescue404
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,4 @@
-class ItemsController < ApplicationController
-
-  before_action :permission_check
+class ItemsController < AdminController
 
   def index
     @items = Item.all
@@ -118,16 +116,5 @@ class ItemsController < ApplicationController
   def new_item_params
     params.require(:item).permit(:item_id,:name,:image,:detail,:maker,:unit_cost, :quantity, :sell_price,:shipping_cost, :item_flg)
   end
-
-
-  def permission_check
-    #権限制御 トップページが出来上がってから動作させる。
-    if user_signed_in?
-      # if current_user.admin_flg == nil
-      #   render "errors/forbidden"
-      # end
-    end
-  end
-
 
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,2 @@
+module AdminHelper
+end

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -1,0 +1,9 @@
+= render "shared/adminheader"
+= render "shared/leftsidebar"
+.adminmainwindow
+  .adminmainwindow__boxes
+    .adminmainwindow__boxes__orders
+    [注文履歴 最新５件]
+    .adminmainwindow__boxes__stocks
+    [在庫数 5未満の商品一覧]
+= render "shared/adminfooter"

--- a/app/views/items/addto.html.haml
+++ b/app/views/items/addto.html.haml
@@ -1,13 +1,20 @@
-= form_for @item do |f|
-  = f.label :item_id, "商品ID"
-  = f.text_field :item_id, placeholder: "商品IDを入力してください"
-
-  = f.label :unit_cost, "仕入単価"
-  = f.text_field :unit_cost, placeholder: "仕入単価を入力してください"
-
-  = f.label :quantity, "仕入数量"
-  = f.text_field :quantity, placeholder: "仕入数量を入力してください"
-
-  = f.hidden_field :item_flg, value:1
-
-  = f.submit value: "Send"
+= render "shared/adminheader"
+= render "shared/leftsidebar"
+.adminmainwindow
+  .adminmainwindow__title
+    [既存商品仕入]
+    = form_for @item do |f|
+      .adminmainwindow__fields
+        = f.label :item_id, "商品ID"
+        = f.text_field :item_id, placeholder: "商品IDを入力してください"
+      .adminmainwindow__fields
+        = f.label :unit_cost, "仕入単価"
+        = f.text_field :unit_cost, placeholder: "仕入単価を入力してください"
+      .adminmainwindow__fields
+        = f.label :quantity, "仕入数量"
+        = f.text_field :quantity, placeholder: "仕入数量を入力してください"
+      .adminmainwindow__fields
+        = f.hidden_field :item_flg, value:1
+      .adminmainwindow__fields
+        = f.submit value: "Send", class: "SendButton"
+= render "shared/adminfooter"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,28 +1,35 @@
-= form_for @item do |f|
-  = f.label :name, "商品名"
-  = f.text_field :name, placeholder: "商品名を修正してください"
-
-  = f.label :image, "商品画像"
-  = f.file_field :image , value: @item.image
-
-  = f.label :detail, "商品詳細"
-  = f.text_field :detail, placeholder: "商品修正を入力してください"
-
-  = f.label :maker, "メーカー"
-  = f.text_field :maker, placeholder: "メーカーを修正してください"
-
-  = f.label :unit_cost, "仕入単価"
-  = f.text_field :unit_cost, placeholder: "仕入単価を修正してください"
-
-  = f.label :quantity, "仕入数量"
-  = f.text_field :quantity, placeholder: "仕入数量を修正してください"
-
-  = f.label :sell_price, "販売価格"
-  = f.text_field :sell_price, placeholder: "販売価格を修正してください"
-
-  = f.label :shipping_cost, "送料"
-  = f.text_field :shipping_cost, placeholder: "送料を修正してください"
-
-  = f.hidden_field :item_flg, value:0
-
-  = f.submit value: "Update"
+= render "shared/adminheader"
+= render "shared/leftsidebar"
+.adminmainwindow
+  .adminmainwindow__title
+    [商品情報編集]
+    = form_for @item do |f|
+      .adminmainwindow__fields
+        = f.label :name, "商品名"
+        = f.text_field :name, placeholder: "商品名を修正してください"
+      .adminmainwindow__fields
+        = f.label :image, "商品画像"
+        = f.file_field :image , value: @item.image
+      .adminmainwindow__fields
+        = f.label :detail, "商品詳細"
+        = f.text_field :detail, placeholder: "商品修正を入力してください"
+      .adminmainwindow__fields
+        = f.label :maker, "メーカー"
+        = f.text_field :maker, placeholder: "メーカーを修正してください"
+      .adminmainwindow__fields
+        = f.label :unit_cost, "仕入単価"
+        = f.text_field :unit_cost, placeholder: "仕入単価を修正してください"
+      .adminmainwindow__fields
+        = f.label :quantity, "仕入数量"
+        = f.text_field :quantity, placeholder: "仕入数量を修正してください"
+      .adminmainwindow__fields
+        = f.label :sell_price, "販売価格"
+        = f.text_field :sell_price, placeholder: "販売価格を修正してください"
+      .adminmainwindow__fields
+        = f.label :shipping_cost, "送料"
+        = f.text_field :shipping_cost, placeholder: "送料を修正してください"
+      .adminmainwindow__fields
+        = f.hidden_field :item_flg, value:0
+      .adminmainwindow__fields
+        = f.submit value: "Update" , class: "SendButton"
+= render "shared/adminfooter"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,68 +1,43 @@
-%table
-  %caption 仕入履歴
-  %tr
-    %th id
-    %th item_id
-    %th name
-    %th image
-    %th detail
-    %th maker
-    %th unit_cost
-    %th quantity
-    %th sell_price
-    %th shipping_cost
-  - @items.each do |item|
-    %tr
-      %td
-        = item.id
-      %td
-        = item.item_id
-      %td
-        = item.name
-      %td
-        = image_tag item.image, width:30, height:24
-      %td
-        = item.detail
-      %td
-        = item.maker
-      %td
-        = item.unit_cost
-      %td
-        = item.quantity
-      %td
-        = item.sell_price
-      %td
-        = item.shipping_cost
-      %td
-        = link_to "編集", "/items/#{item.id}/edit", method: :get
-
-%h3
-  Item Control
-
-%h4
-  = link_to "新規商品を仕入" , "/items/new", method: :get
-%h4
-  = link_to "既存商品を仕入" , "/items/addto", method: :get
-
-%h3
-  User Session Control
-
-%h4
-  - if user_signed_in?
-    - if current_user.admin_flg == true
-      = link_to "AdminTop" , "/admin/"
-
-%h4
-  = link_to "ログイン" , new_user_session_path
-  / ログイン中は表示しないようにする
-
-%h4
-  = link_to "新規登録" , new_user_registration_path
-  / ログイン中は表示しないようにする
-
-%h4
-  = link_to "ユーザ情報変更" , edit_user_registration_path
-
-%h4
-  = link_to "ログアウト" , destroy_user_session_path, method: :delete
-  / ログアウト中は表示しないようにする
+= render "shared/adminheader"
+= render "shared/leftsidebar"
+.adminmainwindow
+  .adminmainwindow__boxes
+    .adminmainwindow__boxes__items
+      [仕入履歴]
+      %table
+        %tr
+          %th id
+          %th item_id
+          %th name
+          %th image
+          %th detail
+          %th maker
+          %th unit_cost
+          %th quantity
+          %th sell_price
+          %th shipping_cost
+        - @items.each do |item|
+          %tr
+            %td
+              = item.id
+            %td
+              = item.item_id
+            %td
+              = item.name
+            %td
+              = image_tag item.image, width:30, height:24
+            %td
+              = item.detail
+            %td
+              = item.maker
+            %td
+              = item.unit_cost
+            %td
+              = item.quantity
+            %td
+              = item.sell_price
+            %td
+              = item.shipping_cost
+            %td
+              = link_to "編集", "/items/#{item.id}/edit",   method: :get
+= render "shared/adminfooter"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,28 +1,35 @@
-= form_for @item do |f|
-  = f.label :name, "商品名"
-  = f.text_field :name, placeholder: "商品名を入力してください"
-
-  = f.label :image, "商品画像"
-  = f.file_field :image
-
-  = f.label :detail, "商品詳細"
-  = f.text_field :detail, placeholder: "商品説明を入力してください"
-
-  = f.label :maker, "メーカー"
-  = f.text_field :maker, placeholder: "メーカーを入力してください"
-
-  = f.label :unit_cost, "仕入単価"
-  = f.text_field :unit_cost, placeholder: "仕入単価を入力してください"
-
-  = f.label :quantity, "仕入数量"
-  = f.text_field :quantity, placeholder: "仕入数量を入力してください"
-
-  = f.label :sell_price, "販売価格"
-  = f.text_field :sell_price, placeholder: "販売価格を入力してください"
-
-  = f.label :shipping_cost, "送料"
-  = f.text_field :shipping_cost, placeholder: "送料を入力してください"
-
-  = f.hidden_field :item_flg, value:0
-
-  = f.submit value: "Send"
+= render "shared/adminheader"
+= render "shared/leftsidebar"
+.adminmainwindow
+  .adminmainwindow__title
+    [新規商品仕入]
+    = form_for @item do |f|
+      .adminmainwindow__fields
+        = f.label :name, "商品名"
+        = f.text_field :name, placeholder: "商品名を入力してください"
+      .adminmainwindow__fields
+        = f.label :image, "商品画像"
+        = f.file_field :image
+      .adminmainwindow__fields
+        = f.label :detail, "商品詳細"
+        = f.text_field :detail, placeholder: "商品説明を入力してください"
+      .adminmainwindow__fields
+        = f.label :maker, "メーカー"
+        = f.text_field :maker, placeholder: "メーカーを入力してください"
+      .adminmainwindow__fields
+        = f.label :unit_cost, "仕入単価"
+        = f.text_field :unit_cost, placeholder: "仕入単価を入力してください"
+      .adminmainwindow__fields
+        = f.label :quantity, "仕入数量"
+        = f.text_field :quantity, placeholder: "仕入数量を入力してください"
+      .adminmainwindow__fields
+        = f.label :sell_price, "販売価格"
+        = f.text_field :sell_price, placeholder: "販売価格を入力してください"
+      .adminmainwindow__fields
+        = f.label :shipping_cost, "送料"
+        = f.text_field :shipping_cost, placeholder: "送料を入力してください"
+      .adminmainwindow__fields
+        = f.hidden_field :item_flg, value:0
+      .adminmainwindow__fields
+        = f.submit value: "Send", class: "SendButton"
+= render "shared/adminfooter"

--- a/app/views/shared/_adminfooter.html.haml
+++ b/app/views/shared/_adminfooter.html.haml
@@ -1,0 +1,5 @@
+.adminfooter
+  .adminfooter__title
+    Amazon Web Site Manager
+  .adminfooter__message
+    All right reserved.

--- a/app/views/shared/_adminheader.html.haml
+++ b/app/views/shared/_adminheader.html.haml
@@ -1,0 +1,13 @@
+.adminheader
+  .adminheader__title
+    Amazon Web Site Manager
+  .adminheader__username
+    ようこそ、
+    %br
+    = current_user.nickname
+    様
+  .adminheader__buttons
+    .adminheader__buttons__sitebutton
+      = link_to "トップページを表示", root_path
+    .adminheader__buttons__logoutbutton
+      = link_to "ログアウト" , destroy_user_session_path, method: :delete

--- a/app/views/shared/_leftsidebar.html.haml
+++ b/app/views/shared/_leftsidebar.html.haml
@@ -1,0 +1,24 @@
+.adminleftwindow
+  .adminleftwindow__linkbox
+    .adminleftwindow__linkbox__title
+      [商品仕入管理]
+    .adminleftwindow__linkbox__links
+      = link_to "仕入一覧ページ", items_path
+    .adminleftwindow__linkbox__links
+      = link_to "新規商品を仕入" , new_item_path
+    .adminleftwindow__linkbox__links
+      = link_to "既存商品を仕入" , addto_items_path
+    .adminleftwindow__linkbox__title
+      [在庫状況管理]
+    .adminleftwindow__linkbox__links
+      = link_to "商品一覧ページ", stocks_path
+    .adminleftwindow__linkbox__title
+      [ユーザ管理]
+    .adminleftwindow__linkbox__links
+      = link_to "管理者ページ", admin_index_path
+    .adminleftwindow__linkbox__links
+      = link_to "管理者情報変更" , edit_user_registration_path
+    .adminleftwindow__linkbox__links
+      = link_to "権限変更", ""
+    .adminleftwindow__linkbox__links
+      = link_to "ログアウト" , destroy_user_session_path, method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,6 @@ Rails.application.routes.draw do
     end
   end
   resources :orders
+  resources :admin, only: [:index]
 
 end

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# WHAT
・admincontroller作成
・itemcontrollerの承継元をadmincontrollerに設定
・管理者用総合ページ/admin実装

# WHY
・権限別管理実装のため
・UI/UX向上のため