### PR TITLE
Revise-payjp-apikey(1-gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@
 
 # Ignore image file
 /public/uploads*
-
-# Ignore Payjp KEYS
-/config/initializers/setting.rb

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -91,7 +91,7 @@ class OrdersController < ApplicationController
     end
 
     #payjpの処理
-    Payjp.api_key = PAYJP_SECRET_KEY
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
       currency: 'jpy',
       amount: total + total_shippingcost,

--- a/config/initializers/setting.rb
+++ b/config/initializers/setting.rb
@@ -1,0 +1,2 @@
+# pay.jp settings
+PAYJP_PUBLIC_KEY = 'pk_test_88023691337ca05f8828911a'


### PR DESCRIPTION
# WHAT
API_KEYの保存方法の修正

# WHY
Pay.jpが２回目以降起動時にエラーを出す問題を解決する