### PR TITLE
Revise-payjp-api_key(2-secret_key)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,7 @@ class ApplicationController < ActionController::Base
 
   # include ErrorHandlers if Rails.env.production? or Rails.env.staging?
 
+
+  # pay.jpのapi_keyの設定
+  Payjp.api_key = ENV['PAYJP_SECRET_KEY']
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -91,7 +91,6 @@ class OrdersController < ApplicationController
     end
 
     #payjpの処理
-    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
       currency: 'jpy',
       amount: total + total_shippingcost,


### PR DESCRIPTION
# WHAT
・SECRET_KEYをapplication_controllerで読み出す事に変更。
・SECRET_KEYを、環境変数に格納することで、setting.rbをgitignoreから外し、gitの管理対象とする。（公開鍵のみ記載）

# WHY
Pay.jpが２回目以降の起動時にエラーを出す問題を解決する