### PR TITLE
Revise payjp(card regist)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,4 +24,29 @@ class ApplicationController < ActionController::Base
 
   # pay.jpのapi_keyの設定
   Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+
+  # 顧客-クレジットカード情報
+  def cardusercheck
+    # pay.jpに、current_user.idを持つユーザが登録されて入ればtrue、そうでなければfalseを返す
+    @payjpusers = Payjp::Customer.all
+    @payjpusers.each do |payjpuser|
+      if payjpuser.id.to_i == current_user.id
+        @existuser_flg = true
+        break
+      else
+        @existuser_flg = false
+      end
+    end
+    return @existuser_flg
+  end
+
+  # 顧客-カード情報取得
+  def gets_usercardinfo
+      @customer_creditcards = Payjp::Customer.retrieve(id: current_user.id.to_s)
+  end
+
+  # 顧客-デフォルトカードid取得
+  def gets_userdefaultcardid
+      @default_cardid = Payjp::Customer.retrieve(id: current_user.id.to_s).default_card
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -11,8 +11,13 @@ class OrdersController < ApplicationController
     # 決済方法の選択画面
     # ギフトの選択画面
     @user = current_user
-    # Payjpに登録されているそのユーザidを持つユーザのクレジットカード情報を取得する。
-    @customer_creditcards = Payjp::Customer.retrieve(id: current_user.id.to_s)
+
+    # そのユーザにカードが登録されているかを調べる(メソッドはapplication_controller.rbに記載)
+    @existuser_flg = cardusercheck
+    if @existuser_flg == true
+      @customer_creditcards = gets_usercardinfo
+      @default_cardid = gets_userdefaultcardid
+    end
   end
 
   def new
@@ -28,8 +33,13 @@ class OrdersController < ApplicationController
       @totalitemyen += cart.quantity * Stock.find(cart.stock_id).sell_price
       @totalshipyen += cart.quantity * Stock.find(cart.stock_id).shipping_cost
     end
-    # Payjpに登録されているそのユーザidを持つユーザのクレジットカード情報を取得する。
-    @customer_creditcards = Payjp::Customer.retrieve(id: current_user.id.to_s)
+
+    # そのユーザにカードが登録されているかを調べる(メソッドはapplication_controller.rbに記載)
+    @existuser_flg = cardusercheck
+    if @existuser_flg == true
+      @customer_creditcards = gets_usercardinfo
+      @default_cardid = gets_userdefaultcardid
+    end
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,14 +14,14 @@ class UsersController < ApplicationController
    	# 現在の年を格納する（クレジットカード情報登録用）
     @year = Time.current.in_time_zone('Tokyo').strftime("%Y").to_i
 
-    # そのユーザにカードが登録されているかを調べる(privateメソッド)
+    # そのユーザにカードが登録されているかを調べる(メソッドはapplication_controller.rbに記載)
     @existuser_flg = cardusercheck
 
 
     # Payjpに登録されているそのユーザidを持つユーザのクレジットカード情報を取得する。
     if @existuser_flg == true
-      @customer_creditcards = Payjp::Customer.retrieve(id: current_user.id.to_s)
-      @default_cardid = Payjp::Customer.retrieve(id: current_user.id.to_s).default_card
+      @customer_creditcards = gets_usercardinfo
+      @default_cardid = gets_userdefaultcardid
     end
    end
 
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
 
     if @existuser_flg == true
       #既存顧客：すでに１枚以上カードがあり、そこに追加する場合
-      customer = Payjp::Customer.retrieve(id: current_user.id.to_s)
+      customer = gets_usercardinfo
       customer.cards.create(
         card: @token_id
       )
@@ -70,21 +70,6 @@ class UsersController < ApplicationController
   private
   def card_params
   	params.permit(:name, :number, :month, :year, :cvc)
-  end
-
-  def cardusercheck
-    #Customer情報の取得
-    # pay.jpに、current_user.idを持つユーザが登録されて入ればtrue、そうでなければfalseを返す
-    @payjpusers = Payjp::Customer.all
-    @payjpusers.each do |payjpuser|
-      if payjpuser.id.to_i == current_user.id
-        @existuser_flg = true
-        break
-      else
-        @existuser_flg = false
-      end
-    end
-    return @existuser_flg
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,8 +14,15 @@ class UsersController < ApplicationController
    	# 現在の年を格納する（クレジットカード情報登録用）
     @year = Time.current.in_time_zone('Tokyo').strftime("%Y").to_i
 
+    # そのユーザにカードが登録されているかを調べる(privateメソッド)
+    @existuser_flg = cardusercheck
+
+
     # Payjpに登録されているそのユーザidを持つユーザのクレジットカード情報を取得する。
-    @customer_creditcards = Payjp::Customer.retrieve(id: current_user.id.to_s)
+    if @existuser_flg == true
+      @customer_creditcards = Payjp::Customer.retrieve(id: current_user.id.to_s)
+      @default_cardid = Payjp::Customer.retrieve(id: current_user.id.to_s).default_card
+    end
    end
 
   def creditcard_regist
@@ -33,12 +40,26 @@ class UsersController < ApplicationController
     )
     @token_id = token.id
 
-    # Pay.jpに顧客を作成（カード情報の保存に必要）
-    Payjp::Customer.create(
-      id: current_user.id,
-      email: current_user.email,
-      card: @token_id
-    )
+
+    # Pay.jpへのカード追加に関わる処理
+    # そのユーザにカードが登録されているかを調べる(privateメソッド)
+    @existuser_flg = cardusercheck
+
+    if @existuser_flg == true
+      #既存顧客：すでに１枚以上カードがあり、そこに追加する場合
+      customer = Payjp::Customer.retrieve(id: current_user.id.to_s)
+      customer.cards.create(
+        card: @token_id
+      )
+    else
+      #新規顧客：１枚もカードがない場合
+      # Pay.jpに顧客を作成（カード情報の保存に必要）
+      Payjp::Customer.create(
+        id: current_user.id,
+        email: current_user.email,
+        card: @token_id
+      )
+    end
 
   	# お支払いオプションページに戻る
     # アラートを出す
@@ -49,6 +70,21 @@ class UsersController < ApplicationController
   private
   def card_params
   	params.permit(:name, :number, :month, :year, :cvc)
+  end
+
+  def cardusercheck
+    #Customer情報の取得
+    # pay.jpに、current_user.idを持つユーザが登録されて入ればtrue、そうでなければfalseを返す
+    @payjpusers = Payjp::Customer.all
+    @payjpusers.each do |payjpuser|
+      if payjpuser.id.to_i == current_user.id
+        @existuser_flg = true
+        break
+      else
+        @existuser_flg = false
+      end
+    end
+    return @existuser_flg
   end
 
 end

--- a/app/views/orders/confirm.html.haml
+++ b/app/views/orders/confirm.html.haml
@@ -117,11 +117,17 @@
     .paymentbox__leftbox__credittitle
       ご登録のクレジットカード
     .borderline
-    .paymentbox__leftbox__credittogglelist
-    - @customer_creditcards.cards.data.each do |creditcard|
-      = creditcard.brand
-      下4桁
-      = creditcard.last4
+    -if @existuser_flg == true
+      - @customer_creditcards.cards.data.each do |creditcard|
+        .paymentbox__leftbox__credittogglelist
+          = creditcard.brand
+          下4桁
+          = creditcard.last4
+          - if creditcard.id == @default_cardid
+            [選択されています]
+    -else
+      登録されているクレジットカードはありません。
+      = link_to "カードを追加", payments_users_path
     .paymentbox__leftbox__nocredittitle
       クレジットカード以外の支払い方法
     .borderline

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -67,9 +67,11 @@
           .paybox__creditmark
             = image_tag "visa_mark.gif"
           .paybox__text
-            - @customer_creditcards.cards.data.each do |creditcard|
-              下4桁
-              = creditcard.last4
+            -if @existuser_flg == true
+              - @customer_creditcards.cards.data.each do |creditcard|
+                -if creditcard.id == @default_cardid
+                  下4桁
+                  = creditcard.last4
         .dembox
           .dembox__title
             請求先住所

--- a/app/views/users/payments.html.haml
+++ b/app/views/users/payments.html.haml
@@ -19,20 +19,23 @@
         .top__limit
           有効期限
     .payoption__rightbox__creditlist
-      - @customer_creditcards.cards.data.each do |creditcard|
-        .credit
-          .credit__mark
-            = image_tag "visa_mark.gif", width:40
-          .credit__text
-            = creditcard.brand
-            下4桁
-            = creditcard.last4
-          .credit__limit
-            = creditcard.exp_month
-            #{"/"}
-            = creditcard.exp_year
-          .credit__listdownmark
-            %i.fa.fa-angle-down
+      -if @existuser_flg == true
+        - @customer_creditcards.cards.data.each do |creditcard|
+          .credit
+            .credit__mark
+              = image_tag "visa_mark.gif", width:40
+            .credit__text
+              = creditcard.brand
+              下4桁
+              = creditcard.last4
+              / - if creditcard.id == @default_cardid
+              /   [デフォルト]
+            .credit__limit
+              = creditcard.exp_month
+              #{"/"}
+              = creditcard.exp_year
+            .credit__listdownmark
+              %i.fa.fa-angle-down
     .payoption__rightbox__toptitle
       残高
     .payoption__rightbox__giftcardbox


### PR DESCRIPTION
# WHAT
・すでにそのユーザidを持ったユーザがpay.jpに登録されている場合にエラーが起きる問題を解決
・カードを登録していない人がusers/paymentにアクセスした時にエラーが起きる問題を解決
・同一部分をメソッド化
・Viewファイルの修正（上記エラーへの対応）

# WHY
バグフィックスのため